### PR TITLE
Supertype mapping

### DIFF
--- a/apache-atlas-adapter/pom.xml
+++ b/apache-atlas-adapter/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>egeria-connector-hadoop-ecosystem</artifactId>
         <groupId>org.odpi.egeria</groupId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apache-atlas-adapter/src/main/java/org/odpi/egeria/connectors/apache/atlas/eventmapper/ApacheAtlasOMRSRepositoryEventMapper.java
+++ b/apache-atlas-adapter/src/main/java/org/odpi/egeria/connectors/apache/atlas/eventmapper/ApacheAtlasOMRSRepositoryEventMapper.java
@@ -24,6 +24,7 @@ import org.odpi.openmetadata.repositoryservices.connectors.openmetadatatopic.Ope
 import org.odpi.openmetadata.repositoryservices.connectors.stores.metadatacollectionstore.properties.instances.*;
 import org.odpi.openmetadata.repositoryservices.connectors.stores.metadatacollectionstore.properties.typedefs.AttributeTypeDef;
 import org.odpi.openmetadata.repositoryservices.connectors.stores.metadatacollectionstore.properties.typedefs.TypeDef;
+import org.odpi.openmetadata.repositoryservices.connectors.stores.metadatacollectionstore.properties.typedefs.TypeDefPatch;
 import org.odpi.openmetadata.repositoryservices.connectors.stores.metadatacollectionstore.repositoryeventmapper.OMRSRepositoryEventMapperBase;
 import org.odpi.openmetadata.repositoryservices.ffdc.exception.RepositoryErrorException;
 import org.slf4j.Logger;
@@ -439,6 +440,21 @@ public class ApacheAtlasOMRSRepositoryEventMapper extends OMRSRepositoryEventMap
                 localServerType,
                 localOrganizationName,
                 newAttributeTypeDef);
+    }
+
+    /**
+     * Sends an updated TypeDef event.
+     *
+     * @param typeDefPatch the patch that was applied to achieve the update
+     */
+    public void sendUpdatedTypeDefEvent(TypeDefPatch typeDefPatch) {
+        repositoryEventProcessor.processUpdatedTypeDefEvent(
+                sourceName,
+                metadataCollectionId,
+                localServerName,
+                localServerType,
+                localOrganizationName,
+                typeDefPatch);
     }
 
     /**

--- a/apache-atlas-adapter/src/main/java/org/odpi/egeria/connectors/apache/atlas/repositoryconnector/ApacheAtlasOMRSMetadataCollection.java
+++ b/apache-atlas-adapter/src/main/java/org/odpi/egeria/connectors/apache/atlas/repositoryconnector/ApacheAtlasOMRSMetadataCollection.java
@@ -19,7 +19,6 @@ import org.odpi.openmetadata.repositoryservices.connectors.stores.metadatacollec
 import org.odpi.openmetadata.repositoryservices.connectors.stores.metadatacollectionstore.properties.typedefs.*;
 import org.odpi.openmetadata.repositoryservices.connectors.stores.metadatacollectionstore.repositoryconnector.OMRSRepositoryHelper;
 import org.odpi.openmetadata.repositoryservices.connectors.stores.metadatacollectionstore.repositoryconnector.OMRSRepositoryValidator;
-import org.odpi.openmetadata.repositoryservices.ffdc.OMRSErrorCode;
 import org.odpi.openmetadata.repositoryservices.ffdc.exception.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -328,6 +327,12 @@ public class ApacheAtlasOMRSMetadataCollection extends OMRSMetadataCollectionBas
 
             typeDefStore.addTypeDef(newTypeDef);
 
+        } else if (typeDefStore.isUnimplementedSupertype(omrsTypeDefName)) {
+
+            // If it's one that we will ultimately inherit from, we should store it as a type
+            // (to support its various properties later on, particularly for updates to the super-types)
+            typeDefStore.addTypeDef(newTypeDef);
+
         } else if (!typeDefStore.isReserved(omrsTypeDefName)) {
 
             if (atlasRepositoryConnector.typeDefExistsByName(omrsTypeDefName)) {
@@ -389,8 +394,9 @@ public class ApacheAtlasOMRSMetadataCollection extends OMRSMetadataCollectionBas
             raiseTypeDefNotSupportedException(ApacheAtlasOMRSErrorCode.TYPEDEF_NOT_SUPPORTED, methodName, null, omrsTypeDefName, repositoryName);
         }
 
-        checkEventMapperIsConfigured(methodName);
-        eventMapper.sendNewTypeDefEvent(newTypeDef);
+        if (eventMapper != null) {
+            eventMapper.sendNewTypeDefEvent(newTypeDef);
+        }
 
     }
 
@@ -451,8 +457,9 @@ public class ApacheAtlasOMRSMetadataCollection extends OMRSMetadataCollectionBas
             raiseTypeDefNotSupportedException(ApacheAtlasOMRSErrorCode.TYPEDEF_NOT_SUPPORTED, methodName, null, omrsTypeDefName, repositoryName);
         }
 
-        checkEventMapperIsConfigured(methodName);
-        eventMapper.sendNewAttributeTypeDefEvent(newAttributeTypeDef);
+        if (eventMapper != null) {
+            eventMapper.sendNewAttributeTypeDefEvent(newAttributeTypeDef);
+        }
 
     }
 
@@ -588,6 +595,73 @@ public class ApacheAtlasOMRSMetadataCollection extends OMRSMetadataCollectionBas
         }
 
         return bImplemented;
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TypeDef updateTypeDef(String userId, TypeDefPatch typeDefPatch) throws
+            InvalidParameterException,
+            RepositoryErrorException,
+            TypeDefNotKnownException,
+            PatchErrorException,
+            FunctionNotSupportedException,
+            UserNotAuthorizedException {
+
+        final String methodName = "updateTypeDef";
+        super.updateTypeDefParameterValidation(userId, typeDefPatch, methodName);
+
+        String omrsTypeDefName = typeDefPatch.getTypeDefName();
+        String omrsTypeDefGUID = typeDefPatch.getTypeDefGUID();
+        TypeDef existing = typeDefStore.getTypeDefByGUID(omrsTypeDefGUID);
+        TypeDef revised = null;
+
+        if (existing != null) {
+            log.info("Updating TypeDef '{}' based on patch.", omrsTypeDefName);
+            revised = repositoryHelper.applyPatch(atlasRepositoryConnector.getServerName(), existing, typeDefPatch);
+            // TODO: update the Atlas type itself first?
+            switch(revised.getCategory()) {
+                case ENTITY_DEF:
+                    // For a mapped type (entity) that already exists, all we need to do is update the stored
+                    // TypeDef itself -- the mapping will not change for read-only connectivity
+                    break;
+                case RELATIONSHIP_DEF:
+                    RelationshipDefMapping.updateRelationshipTypeInAtlas(
+                            (RelationshipDef) revised,
+                            typeDefStore,
+                            attributeTypeDefStore,
+                            atlasRepositoryConnector
+                    );
+                    break;
+                case CLASSIFICATION_DEF:
+                    ClassificationDefMapping.updateClassificationTypeInAtlas(
+                            (ClassificationDef) revised,
+                            typeDefStore,
+                            attributeTypeDefStore,
+                            atlasRepositoryConnector
+                    );
+                    break;
+                default:
+                    typeDefStore.addUnimplementedTypeDef(revised);
+                    raiseTypeDefNotKnownException(ApacheAtlasOMRSErrorCode.TYPEDEF_NOT_SUPPORTED, methodName, null, omrsTypeDefName, repositoryName);
+            }
+            typeDefStore.addTypeDef(revised);
+            if (eventMapper != null) {
+                eventMapper.sendUpdatedTypeDefEvent(typeDefPatch);
+            }
+        } else {
+            // Still need to update unimplemented TypeDefs so that we have the latest for supertypes
+            log.info("Updating unmapped TypeDef '{}' based on patch.", omrsTypeDefName);
+            TypeDef unimplemented = typeDefStore.getUnimplementedTypeDefByGUID(omrsTypeDefGUID);
+            if (unimplemented != null) {
+                revised = repositoryHelper.applyPatch(atlasRepositoryConnector.getServerName(), unimplemented, typeDefPatch);
+            }
+            raiseTypeDefNotKnownException(ApacheAtlasOMRSErrorCode.TYPEDEF_NOT_SUPPORTED, methodName, null, omrsTypeDefName, repositoryName);
+        }
+
+        return revised;
 
     }
 
@@ -1445,28 +1519,31 @@ public class ApacheAtlasOMRSMetadataCollection extends OMRSMetadataCollectionBas
                 homeParameterName,
                 methodName);
 
-        /*
-         * Validate that the entity GUID is ok
-         */
-        EntityDetail entity = this.isEntityKnown(userId, entityGUID);
-        if (entity != null) {
-            if (metadataCollectionId.equals(entity.getMetadataCollectionId())) {
-                throw new HomeEntityException(ApacheAtlasOMRSErrorCode.HOME_REFRESH.getMessageDefinition(methodName, entityGUID, metadataCollectionId, repositoryName),
-                        this.getClass().getName(),
-                        methodName);
+        // Only bother doing any work if there is an event mapper configured into which to actually push
+        // the refresh event
+        if (eventMapper != null) {
+            /*
+             * Validate that the entity GUID is ok
+             */
+            EntityDetail entity = this.isEntityKnown(userId, entityGUID);
+            if (entity != null) {
+                if (metadataCollectionId.equals(entity.getMetadataCollectionId())) {
+                    throw new HomeEntityException(ApacheAtlasOMRSErrorCode.HOME_REFRESH.getMessageDefinition(methodName, entityGUID, metadataCollectionId, repositoryName),
+                            this.getClass().getName(),
+                            methodName);
+                }
             }
-        }
 
-        /*
-         * Send refresh message
-         */
-        checkEventMapperIsConfigured(methodName);
-        eventMapper.sendRefreshEntityRequest(
-                typeDefGUID,
-                typeDefName,
-                entityGUID,
-                homeMetadataCollectionId
-        );
+            /*
+             * Send refresh message
+             */
+            eventMapper.sendRefreshEntityRequest(
+                    typeDefGUID,
+                    typeDefName,
+                    entityGUID,
+                    homeMetadataCollectionId
+            );
+        }
 
     }
 
@@ -1500,25 +1577,28 @@ public class ApacheAtlasOMRSMetadataCollection extends OMRSMetadataCollectionBas
                 homeParameterName,
                 methodName);
 
-        Relationship relationship = this.isRelationshipKnown(userId, relationshipGUID);
-        if (relationship != null) {
-            if (metadataCollectionId.equals(relationship.getMetadataCollectionId())) {
-                throw new HomeRelationshipException(ApacheAtlasOMRSErrorCode.HOME_REFRESH.getMessageDefinition(methodName, relationshipGUID, metadataCollectionId, repositoryName),
-                        this.getClass().getName(),
-                        methodName);
+        // Only bother doing any work if there is an event mapper configured into which to actually push
+        // the refresh event
+        if (eventMapper != null) {
+            Relationship relationship = this.isRelationshipKnown(userId, relationshipGUID);
+            if (relationship != null) {
+                if (metadataCollectionId.equals(relationship.getMetadataCollectionId())) {
+                    throw new HomeRelationshipException(ApacheAtlasOMRSErrorCode.HOME_REFRESH.getMessageDefinition(methodName, relationshipGUID, metadataCollectionId, repositoryName),
+                            this.getClass().getName(),
+                            methodName);
+                }
             }
-        }
 
-        /*
-         * Process refresh request
-         */
-        checkEventMapperIsConfigured(methodName);
-        eventMapper.sendRefreshRelationshipRequest(
-                typeDefGUID,
-                typeDefName,
-                relationshipGUID,
-                homeMetadataCollectionId
-        );
+            /*
+             * Process refresh request
+             */
+            eventMapper.sendRefreshRelationshipRequest(
+                    typeDefGUID,
+                    typeDefName,
+                    relationshipGUID,
+                    homeMetadataCollectionId
+            );
+        }
 
     }
 
@@ -1572,12 +1652,15 @@ public class ApacheAtlasOMRSMetadataCollection extends OMRSMetadataCollectionBas
             TypeDef typeDef = typeDefStore.getTypeDefByGUID(entityTypeGUID, false);
             if (typeDef != null) {
                 String omrsTypeName = typeDef.getName();
-                atlasTypeNamesByPrefix = typeDefStore.getAllMappedAtlasTypeDefNames(omrsTypeName);
-                results.put(omrsTypeName, atlasTypeNamesByPrefix);
+                if (typeDefStore.isUnimplementedSupertype(omrsTypeName)) {
+                    requestedTypeName = omrsTypeName;
+                } else {
+                    atlasTypeNamesByPrefix = typeDefStore.getAllMappedAtlasTypeDefNames(omrsTypeName);
+                    results.put(omrsTypeName, atlasTypeNamesByPrefix);
+                }
             } else {
                 TypeDef unimplemented = typeDefStore.getUnimplementedTypeDefByGUID(entityTypeGUID);
                 requestedTypeName = unimplemented.getName();
-                log.warn("Unable to search for type, unknown to repository: {}", entityTypeGUID);
             }
         } else {
             atlasTypeNamesByPrefix.put(null, "Referenceable");
@@ -1591,7 +1674,9 @@ public class ApacheAtlasOMRSMetadataCollection extends OMRSMetadataCollectionBas
                 List<TypeDef> allEntityTypes = findTypeDefsByCategory(userId, TypeDefCategory.ENTITY_DEF);
                 for (TypeDef typeDef : allEntityTypes) {
                     String typeDefName = typeDef.getName();
-                    if (!typeDefName.equals("Referenceable") && repositoryHelper.isTypeOf(metadataCollectionId, typeDefName, requestedTypeName)) {
+                    if (!typeDefName.equals("Referenceable")
+                            && !typeDefStore.isUnimplementedSupertype(typeDefName)
+                            && repositoryHelper.isTypeOf(metadataCollectionId, typeDefName, requestedTypeName)) {
                         Map<String, String> mappings = typeDefStore.getAllMappedAtlasTypeDefNames(typeDefName);
                         if (!mappings.isEmpty()) {
                             results.put(typeDefName, mappings);
@@ -1605,19 +1690,6 @@ public class ApacheAtlasOMRSMetadataCollection extends OMRSMetadataCollectionBas
 
         return results;
 
-    }
-
-    /**
-     * Ensure that the event mapper is configured and throw exception if it is not.
-     *
-     * @param methodName the method attempting to use the event mapper
-     */
-    private void checkEventMapperIsConfigured(String methodName) throws RepositoryErrorException {
-        if (eventMapper == null) {
-            throw new RepositoryErrorException(ApacheAtlasOMRSErrorCode.EVENT_MAPPER_NOT_INITIALIZED.getMessageDefinition(repositoryName),
-                    this.getClass().getName(),
-                    methodName);
-        }
     }
 
     /**
@@ -2196,189 +2268,190 @@ public class ApacheAtlasOMRSMetadataCollection extends OMRSMetadataCollectionBas
         final String methodName = "addSearchConditionFromValue";
 
         if (omrsPropertyName != null) {
-            String atlasPropertyName = omrsToAtlasPropertyMap.get(omrsPropertyName);
-            if (atlasPropertyName != null) {
+            if (omrsToAtlasPropertyMap != null) {
+                String atlasPropertyName = omrsToAtlasPropertyMap.get(omrsPropertyName);
+                if (atlasPropertyName != null) {
 
-                SearchParameters.FilterCriteria atlasCriterion = new SearchParameters.FilterCriteria();
-                StringBuilder sbCriterion = new StringBuilder();
-                InstancePropertyCategory category = value.getInstancePropertyCategory();
-                switch (category) {
-                    case PRIMITIVE:
-                        PrimitivePropertyValue actualValue = (PrimitivePropertyValue) value;
-                        PrimitiveDefCategory primitiveType = actualValue.getPrimitiveDefCategory();
-                        switch (primitiveType) {
-                            case OM_PRIMITIVE_TYPE_BOOLEAN:
-                            case OM_PRIMITIVE_TYPE_SHORT:
-                            case OM_PRIMITIVE_TYPE_INT:
-                            case OM_PRIMITIVE_TYPE_LONG:
-                            case OM_PRIMITIVE_TYPE_FLOAT:
-                            case OM_PRIMITIVE_TYPE_DOUBLE:
-                            case OM_PRIMITIVE_TYPE_BIGINTEGER:
-                            case OM_PRIMITIVE_TYPE_BIGDECIMAL:
-                                String nonString = actualValue.getPrimitiveValue().toString();
-                                atlasCriterion.setAttributeName(atlasPropertyName);
-                                sbCriterion.append(atlasPropertyName);
-                                if (negateCondition) {
-                                    atlasCriterion.setOperator(SearchParameters.Operator.NEQ);
-                                    sbCriterion.append(" != ");
-                                } else {
-                                    atlasCriterion.setOperator(SearchParameters.Operator.EQ);
-                                    sbCriterion.append(" = ");
-                                }
-                                atlasCriterion.setAttributeValue(nonString);
-                                sbCriterion.append(nonString);
-                                if (dslQuery) {
-                                    criteria.add((T) sbCriterion.toString());
-                                } else {
-                                    criteria.add((T) atlasCriterion);
-                                }
-                                break;
-                            case OM_PRIMITIVE_TYPE_BYTE:
-                            case OM_PRIMITIVE_TYPE_CHAR:
-                                String single = actualValue.getPrimitiveValue().toString();
-                                atlasCriterion.setAttributeName(atlasPropertyName);
-                                sbCriterion.append(atlasPropertyName);
-                                if (negateCondition) {
-                                    atlasCriterion.setOperator(SearchParameters.Operator.NEQ);
-                                    sbCriterion.append(" != \"");
-                                } else {
-                                    atlasCriterion.setOperator(SearchParameters.Operator.EQ);
-                                    sbCriterion.append(" = \"");
-                                }
-                                atlasCriterion.setAttributeValue(single);
-                                sbCriterion.append(single);
-                                sbCriterion.append("\"");
-                                if (dslQuery) {
-                                    criteria.add((T) sbCriterion.toString());
-                                } else {
-                                    criteria.add((T) atlasCriterion);
-                                }
-                                break;
-                            case OM_PRIMITIVE_TYPE_DATE:
-                                Long epoch = (Long) actualValue.getPrimitiveValue();
-                                String formattedDate = atlasDateFormat.format(new Date(epoch));
-                                atlasCriterion.setAttributeName(atlasPropertyName);
-                                if (atlasPropertyName.equals("createTime")) {
-                                    sbCriterion.append("__timestamp");
-                                } else if (atlasPropertyName.equals("updateTime")) {
-                                    sbCriterion.append("__modificationTimestamp");
-                                } else {
+                    SearchParameters.FilterCriteria atlasCriterion = new SearchParameters.FilterCriteria();
+                    StringBuilder sbCriterion = new StringBuilder();
+                    InstancePropertyCategory category = value.getInstancePropertyCategory();
+                    switch (category) {
+                        case PRIMITIVE:
+                            PrimitivePropertyValue actualValue = (PrimitivePropertyValue) value;
+                            PrimitiveDefCategory primitiveType = actualValue.getPrimitiveDefCategory();
+                            switch (primitiveType) {
+                                case OM_PRIMITIVE_TYPE_BOOLEAN:
+                                case OM_PRIMITIVE_TYPE_SHORT:
+                                case OM_PRIMITIVE_TYPE_INT:
+                                case OM_PRIMITIVE_TYPE_LONG:
+                                case OM_PRIMITIVE_TYPE_FLOAT:
+                                case OM_PRIMITIVE_TYPE_DOUBLE:
+                                case OM_PRIMITIVE_TYPE_BIGINTEGER:
+                                case OM_PRIMITIVE_TYPE_BIGDECIMAL:
+                                    String nonString = actualValue.getPrimitiveValue().toString();
+                                    atlasCriterion.setAttributeName(atlasPropertyName);
                                     sbCriterion.append(atlasPropertyName);
-                                }
-                                if (negateCondition) {
-                                    atlasCriterion.setOperator(SearchParameters.Operator.NEQ);
-                                    sbCriterion.append(" != \"");
-                                } else {
-                                    atlasCriterion.setOperator(SearchParameters.Operator.EQ);
-                                    sbCriterion.append(" = \"");
-                                }
-                                atlasCriterion.setAttributeValue(formattedDate);
-                                sbCriterion.append(epoch);
-                                sbCriterion.append("\"");
-                                if (dslQuery) {
-                                    criteria.add((T) sbCriterion.toString());
-                                } else {
-                                    criteria.add((T) atlasCriterion);
-                                }
-                                break;
-                            case OM_PRIMITIVE_TYPE_STRING:
-                            default:
-                                atlasCriterion.setAttributeName(atlasPropertyName);
-                                sbCriterion.append(atlasPropertyName);
-                                String candidateValue = actualValue.getPrimitiveValue().toString();
-                                String unqualifiedValue = repositoryHelper.getUnqualifiedLiteralString(candidateValue);
-                                if (repositoryHelper.isContainsRegex(candidateValue)) {
-                                    sbCriterion.append(" LIKE \"*");
-                                    sbCriterion.append(unqualifiedValue);
-                                    sbCriterion.append("\"*");
-                                    atlasCriterion.setOperator(SearchParameters.Operator.CONTAINS);
-                                } else if (repositoryHelper.isEndsWithRegex(candidateValue)) {
-                                    sbCriterion.append(" LIKE \"*");
-                                    sbCriterion.append(unqualifiedValue);
-                                    sbCriterion.append("\"");
-                                    atlasCriterion.setOperator(SearchParameters.Operator.ENDS_WITH);
-                                } else if (repositoryHelper.isStartsWithRegex(candidateValue)) {
-                                    sbCriterion.append(" LIKE \"");
-                                    sbCriterion.append(unqualifiedValue);
-                                    sbCriterion.append("*\"");
-                                    atlasCriterion.setOperator(SearchParameters.Operator.STARTS_WITH);
-                                } else if (repositoryHelper.isExactMatchRegex(candidateValue)) {
                                     if (negateCondition) {
-                                        if (unqualifiedValue.equals("")) {
-                                            atlasCriterion.setOperator(SearchParameters.Operator.NOT_NULL);
-                                        } else {
-                                            atlasCriterion.setOperator(SearchParameters.Operator.NEQ);
-                                        }
-                                        sbCriterion.append(" != \"");
+                                        atlasCriterion.setOperator(SearchParameters.Operator.NEQ);
+                                        sbCriterion.append(" != ");
                                     } else {
-                                        if (unqualifiedValue.equals("")) {
-                                            atlasCriterion.setOperator(SearchParameters.Operator.IS_NULL);
-                                        } else {
-                                            atlasCriterion.setOperator(SearchParameters.Operator.EQ);
-                                        }
-                                        sbCriterion.append(" = \"");
+                                        atlasCriterion.setOperator(SearchParameters.Operator.EQ);
+                                        sbCriterion.append(" = ");
                                     }
-                                    sbCriterion.append(unqualifiedValue);
-                                    sbCriterion.append("\"");
-                                } else {
-                                    raiseFunctionNotSupportedException(ApacheAtlasOMRSErrorCode.REGEX_NOT_IMPLEMENTED, methodName, repositoryName, candidateValue);
-                                }
-                                atlasCriterion.setAttributeValue(unqualifiedValue);
-                                if (dslQuery) {
-                                    criteria.add((T) sbCriterion.toString());
-                                } else {
-                                    criteria.add((T) atlasCriterion);
-                                }
-                                break;
-                        }
-                        break;
-                    case ENUM:
-                        String omrsEnumValue = ((EnumPropertyValue) value).getSymbolicName();
-                        TypeDefAttribute typeDefAttribute = omrsTypeDefAttrMap.get(omrsPropertyName);
-                        if (typeDefAttribute != null) {
-                            Map<String, Set<String>> elementMap = attributeTypeDefStore.getElementMappingsForOMRSTypeDef(typeDefAttribute.getAttributeType().getName());
-                            if (elementMap != null) {
-                                Set<String> atlasEnumValues = elementMap.get(omrsEnumValue);
-                                if (atlasEnumValues != null && !atlasEnumValues.isEmpty()) {
-                                    // build a list of the OR-able sub-conditions
-                                    List<SearchParameters.FilterCriteria> subAtlasCriteria = new ArrayList<>();
-                                    List<String> subCriteria = new ArrayList<>();
-                                    sbCriterion.append("(");
-                                    for (String atlasEnumValue : atlasEnumValues) {
-                                        StringBuilder subCriterion = new StringBuilder();
-                                        SearchParameters.FilterCriteria subAtlasCriterion = new SearchParameters.FilterCriteria();
-                                        subAtlasCriterion.setAttributeName(atlasPropertyName);
-                                        subCriterion.append(atlasPropertyName);
-                                        if (negateCondition) {
-                                            subAtlasCriterion.setOperator(SearchParameters.Operator.NEQ);
-                                            subCriterion.append(" != \"");
-                                        } else {
-                                            subAtlasCriterion.setOperator(SearchParameters.Operator.EQ);
-                                            subCriterion.append(" = \"");
-                                        }
-                                        subAtlasCriterion.setAttributeValue(atlasEnumValue);
-                                        subCriterion.append(atlasEnumValue);
-                                        subCriterion.append("\"");
-                                        subAtlasCriteria.add(subAtlasCriterion);
-                                        subCriteria.add(subCriterion.toString());
-                                    }
-                                    sbCriterion.append(String.join(" OR ", subCriteria));
-                                    sbCriterion.append(")");
-                                    atlasCriterion.setCriterion(subAtlasCriteria);
-                                    atlasCriterion.setCondition(SearchParameters.FilterCriteria.Condition.OR);
+                                    atlasCriterion.setAttributeValue(nonString);
+                                    sbCriterion.append(nonString);
                                     if (dslQuery) {
                                         criteria.add((T) sbCriterion.toString());
                                     } else {
                                         criteria.add((T) atlasCriterion);
                                     }
-                                } else {
-                                    log.warn("Unable to find mapped enum value for {}: {}", omrsPropertyName, omrsEnumValue);
-                                }
+                                    break;
+                                case OM_PRIMITIVE_TYPE_BYTE:
+                                case OM_PRIMITIVE_TYPE_CHAR:
+                                    String single = actualValue.getPrimitiveValue().toString();
+                                    atlasCriterion.setAttributeName(atlasPropertyName);
+                                    sbCriterion.append(atlasPropertyName);
+                                    if (negateCondition) {
+                                        atlasCriterion.setOperator(SearchParameters.Operator.NEQ);
+                                        sbCriterion.append(" != \"");
+                                    } else {
+                                        atlasCriterion.setOperator(SearchParameters.Operator.EQ);
+                                        sbCriterion.append(" = \"");
+                                    }
+                                    atlasCriterion.setAttributeValue(single);
+                                    sbCriterion.append(single);
+                                    sbCriterion.append("\"");
+                                    if (dslQuery) {
+                                        criteria.add((T) sbCriterion.toString());
+                                    } else {
+                                        criteria.add((T) atlasCriterion);
+                                    }
+                                    break;
+                                case OM_PRIMITIVE_TYPE_DATE:
+                                    Long epoch = (Long) actualValue.getPrimitiveValue();
+                                    String formattedDate = atlasDateFormat.format(new Date(epoch));
+                                    atlasCriterion.setAttributeName(atlasPropertyName);
+                                    if (atlasPropertyName.equals("createTime")) {
+                                        sbCriterion.append("__timestamp");
+                                    } else if (atlasPropertyName.equals("updateTime")) {
+                                        sbCriterion.append("__modificationTimestamp");
+                                    } else {
+                                        sbCriterion.append(atlasPropertyName);
+                                    }
+                                    if (negateCondition) {
+                                        atlasCriterion.setOperator(SearchParameters.Operator.NEQ);
+                                        sbCriterion.append(" != \"");
+                                    } else {
+                                        atlasCriterion.setOperator(SearchParameters.Operator.EQ);
+                                        sbCriterion.append(" = \"");
+                                    }
+                                    atlasCriterion.setAttributeValue(formattedDate);
+                                    sbCriterion.append(epoch);
+                                    sbCriterion.append("\"");
+                                    if (dslQuery) {
+                                        criteria.add((T) sbCriterion.toString());
+                                    } else {
+                                        criteria.add((T) atlasCriterion);
+                                    }
+                                    break;
+                                case OM_PRIMITIVE_TYPE_STRING:
+                                default:
+                                    atlasCriterion.setAttributeName(atlasPropertyName);
+                                    sbCriterion.append(atlasPropertyName);
+                                    String candidateValue = actualValue.getPrimitiveValue().toString();
+                                    String unqualifiedValue = repositoryHelper.getUnqualifiedLiteralString(candidateValue);
+                                    if (repositoryHelper.isContainsRegex(candidateValue)) {
+                                        sbCriterion.append(" LIKE \"*");
+                                        sbCriterion.append(unqualifiedValue);
+                                        sbCriterion.append("\"*");
+                                        atlasCriterion.setOperator(SearchParameters.Operator.CONTAINS);
+                                    } else if (repositoryHelper.isEndsWithRegex(candidateValue)) {
+                                        sbCriterion.append(" LIKE \"*");
+                                        sbCriterion.append(unqualifiedValue);
+                                        sbCriterion.append("\"");
+                                        atlasCriterion.setOperator(SearchParameters.Operator.ENDS_WITH);
+                                    } else if (repositoryHelper.isStartsWithRegex(candidateValue)) {
+                                        sbCriterion.append(" LIKE \"");
+                                        sbCriterion.append(unqualifiedValue);
+                                        sbCriterion.append("*\"");
+                                        atlasCriterion.setOperator(SearchParameters.Operator.STARTS_WITH);
+                                    } else if (repositoryHelper.isExactMatchRegex(candidateValue)) {
+                                        if (negateCondition) {
+                                            if (unqualifiedValue.equals("")) {
+                                                atlasCriterion.setOperator(SearchParameters.Operator.NOT_NULL);
+                                            } else {
+                                                atlasCriterion.setOperator(SearchParameters.Operator.NEQ);
+                                            }
+                                            sbCriterion.append(" != \"");
+                                        } else {
+                                            if (unqualifiedValue.equals("")) {
+                                                atlasCriterion.setOperator(SearchParameters.Operator.IS_NULL);
+                                            } else {
+                                                atlasCriterion.setOperator(SearchParameters.Operator.EQ);
+                                            }
+                                            sbCriterion.append(" = \"");
+                                        }
+                                        sbCriterion.append(unqualifiedValue);
+                                        sbCriterion.append("\"");
+                                    } else {
+                                        raiseFunctionNotSupportedException(ApacheAtlasOMRSErrorCode.REGEX_NOT_IMPLEMENTED, methodName, repositoryName, candidateValue);
+                                    }
+                                    atlasCriterion.setAttributeValue(unqualifiedValue);
+                                    if (dslQuery) {
+                                        criteria.add((T) sbCriterion.toString());
+                                    } else {
+                                        criteria.add((T) atlasCriterion);
+                                    }
+                                    break;
                             }
-                        } else {
-                            log.warn("Unable to find enum with name: {}", omrsPropertyName);
-                        }
-                        break;
+                            break;
+                        case ENUM:
+                            String omrsEnumValue = ((EnumPropertyValue) value).getSymbolicName();
+                            TypeDefAttribute typeDefAttribute = omrsTypeDefAttrMap.get(omrsPropertyName);
+                            if (typeDefAttribute != null) {
+                                Map<String, Set<String>> elementMap = attributeTypeDefStore.getElementMappingsForOMRSTypeDef(typeDefAttribute.getAttributeType().getName());
+                                if (elementMap != null) {
+                                    Set<String> atlasEnumValues = elementMap.get(omrsEnumValue);
+                                    if (atlasEnumValues != null && !atlasEnumValues.isEmpty()) {
+                                        // build a list of the OR-able sub-conditions
+                                        List<SearchParameters.FilterCriteria> subAtlasCriteria = new ArrayList<>();
+                                        List<String> subCriteria = new ArrayList<>();
+                                        sbCriterion.append("(");
+                                        for (String atlasEnumValue : atlasEnumValues) {
+                                            StringBuilder subCriterion = new StringBuilder();
+                                            SearchParameters.FilterCriteria subAtlasCriterion = new SearchParameters.FilterCriteria();
+                                            subAtlasCriterion.setAttributeName(atlasPropertyName);
+                                            subCriterion.append(atlasPropertyName);
+                                            if (negateCondition) {
+                                                subAtlasCriterion.setOperator(SearchParameters.Operator.NEQ);
+                                                subCriterion.append(" != \"");
+                                            } else {
+                                                subAtlasCriterion.setOperator(SearchParameters.Operator.EQ);
+                                                subCriterion.append(" = \"");
+                                            }
+                                            subAtlasCriterion.setAttributeValue(atlasEnumValue);
+                                            subCriterion.append(atlasEnumValue);
+                                            subCriterion.append("\"");
+                                            subAtlasCriteria.add(subAtlasCriterion);
+                                            subCriteria.add(subCriterion.toString());
+                                        }
+                                        sbCriterion.append(String.join(" OR ", subCriteria));
+                                        sbCriterion.append(")");
+                                        atlasCriterion.setCriterion(subAtlasCriteria);
+                                        atlasCriterion.setCondition(SearchParameters.FilterCriteria.Condition.OR);
+                                        if (dslQuery) {
+                                            criteria.add((T) sbCriterion.toString());
+                                        } else {
+                                            criteria.add((T) atlasCriterion);
+                                        }
+                                    } else {
+                                        log.warn("Unable to find mapped enum value for {}: {}", omrsPropertyName, omrsEnumValue);
+                                    }
+                                }
+                            } else {
+                                log.warn("Unable to find enum with name: {}", omrsPropertyName);
+                            }
+                            break;
                     /*case STRUCT:
                         Map<String, InstancePropertyValue> structValues = ((StructPropertyValue) value).getAttributes().getInstanceProperties();
                         for (Map.Entry<String, InstancePropertyValue> nextEntry : structValues.entrySet()) {
@@ -2391,42 +2464,45 @@ public class ApacheAtlasOMRSMetadataCollection extends OMRSMetadataCollectionBas
                             );
                         }
                         break;*/
-                    case MAP:
-                        Map<String, InstancePropertyValue> mapValues = ((MapPropertyValue) value).getMapValues().getInstanceProperties();
-                        for (Map.Entry<String, InstancePropertyValue> nextEntry : mapValues.entrySet()) {
-                            addSearchConditionFromValue(
-                                    criteria,
-                                    nextEntry.getKey(),
-                                    nextEntry.getValue(),
-                                    omrsToAtlasPropertyMap,
-                                    omrsTypeDefAttrMap,
-                                    negateCondition,
-                                    dslQuery
-                            );
-                        }
-                        break;
-                    case ARRAY:
-                        Map<String, InstancePropertyValue> arrayValues = ((ArrayPropertyValue) value).getArrayValues().getInstanceProperties();
-                        for (Map.Entry<String, InstancePropertyValue> nextEntry : arrayValues.entrySet()) {
-                            addSearchConditionFromValue(
-                                    criteria,
-                                    atlasPropertyName,
-                                    nextEntry.getValue(),
-                                    omrsToAtlasPropertyMap,
-                                    omrsTypeDefAttrMap,
-                                    negateCondition,
-                                    dslQuery
-                            );
-                        }
-                        break;
-                    default:
-                        // Do nothing
-                        log.warn("Unable to handle search criteria for value type: {}", category);
-                        break;
-                }
+                        case MAP:
+                            Map<String, InstancePropertyValue> mapValues = ((MapPropertyValue) value).getMapValues().getInstanceProperties();
+                            for (Map.Entry<String, InstancePropertyValue> nextEntry : mapValues.entrySet()) {
+                                addSearchConditionFromValue(
+                                        criteria,
+                                        nextEntry.getKey(),
+                                        nextEntry.getValue(),
+                                        omrsToAtlasPropertyMap,
+                                        omrsTypeDefAttrMap,
+                                        negateCondition,
+                                        dslQuery
+                                );
+                            }
+                            break;
+                        case ARRAY:
+                            Map<String, InstancePropertyValue> arrayValues = ((ArrayPropertyValue) value).getArrayValues().getInstanceProperties();
+                            for (Map.Entry<String, InstancePropertyValue> nextEntry : arrayValues.entrySet()) {
+                                addSearchConditionFromValue(
+                                        criteria,
+                                        atlasPropertyName,
+                                        nextEntry.getValue(),
+                                        omrsToAtlasPropertyMap,
+                                        omrsTypeDefAttrMap,
+                                        negateCondition,
+                                        dslQuery
+                                );
+                            }
+                            break;
+                        default:
+                            // Do nothing
+                            log.warn("Unable to handle search criteria for value type: {}", category);
+                            break;
+                    }
 
+                } else {
+                    log.warn("Unable to add search condition, no mapped Atlas property for '{}': {}", omrsPropertyName, value);
+                }
             } else {
-                log.warn("Unable to add search condition, no mapped Atlas property for '{}': {}", omrsPropertyName, value);
+                log.info("Unable to add search condition, no mapped Atlas property for property: {}", omrsPropertyName);
             }
         } else {
             log.warn("Unable to add search condition, no OMRS property: {}", value);

--- a/apache-atlas-adapter/src/main/java/org/odpi/egeria/connectors/apache/atlas/repositoryconnector/ApacheAtlasOMRSRepositoryConnector.java
+++ b/apache-atlas-adapter/src/main/java/org/odpi/egeria/connectors/apache/atlas/repositoryconnector/ApacheAtlasOMRSRepositoryConnector.java
@@ -190,10 +190,21 @@ public class ApacheAtlasOMRSRepositoryConnector extends OMRSRepositoryConnector 
      *
      * @param typeDefs the TypeDefs to add to Apache Atlas
      * @return AtlasTypesDef
-     * @throws AtlasServiceException if there is any error retrieving the relationship
+     * @throws AtlasServiceException if there is any error creating the type definition
      */
     public AtlasTypesDef createTypeDef(AtlasTypesDef typeDefs) throws AtlasServiceException {
         return atlasClient.createAtlasTypeDefs(typeDefs);
+    }
+
+    /**
+     * Updates the list of TypeDefs provided in Apache Atlas.
+     *
+     * @param typeDefs the TypeDefs to update in Apache Atlas
+     * @return AtlasTypesDef
+     * @throws AtlasServiceException if there is any error applying the update
+     */
+    public AtlasTypesDef updateTypeDef(AtlasTypesDef typeDefs) throws AtlasServiceException {
+        return atlasClient.updateAtlasTypeDefs(typeDefs);
     }
 
     /**

--- a/apache-atlas-adapter/src/main/java/org/odpi/egeria/connectors/apache/atlas/repositoryconnector/mapping/BaseTypeDefMapping.java
+++ b/apache-atlas-adapter/src/main/java/org/odpi/egeria/connectors/apache/atlas/repositoryconnector/mapping/BaseTypeDefMapping.java
@@ -3,8 +3,11 @@
 package org.odpi.egeria.connectors.apache.atlas.repositoryconnector.mapping;
 
 import org.apache.atlas.model.typedef.*;
+import org.odpi.egeria.connectors.apache.atlas.auditlog.ApacheAtlasOMRSErrorCode;
 import org.odpi.egeria.connectors.apache.atlas.repositoryconnector.stores.AttributeTypeDefStore;
 import org.odpi.openmetadata.repositoryservices.connectors.stores.metadatacollectionstore.properties.typedefs.*;
+import org.odpi.openmetadata.repositoryservices.ffdc.exception.PatchErrorException;
+import org.odpi.openmetadata.repositoryservices.ffdc.exception.TypeDefNotSupportedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -181,6 +184,48 @@ class BaseTypeDefMapping {
 
         return atlasName;
 
+    }
+
+    /**
+     * Throws a TypeDefNotSupportedException using the provided parameters.
+     * @param errorCode the error code for the exception
+     * @param methodName the method throwing the exception
+     * @param cause the underlying cause of the exception (if any, otherwise null)
+     * @param params any parameters for formatting the error message
+     * @throws TypeDefNotSupportedException always
+     */
+    protected static void raiseTypeDefNotSupportedException(ApacheAtlasOMRSErrorCode errorCode, String methodName, Throwable cause, String ...params) throws TypeDefNotSupportedException {
+        if (cause == null) {
+            throw new TypeDefNotSupportedException(errorCode.getMessageDefinition(params),
+                    RelationshipDefMapping.class.getName(),
+                    methodName);
+        } else {
+            throw new TypeDefNotSupportedException(errorCode.getMessageDefinition(params),
+                    RelationshipDefMapping.class.getName(),
+                    methodName,
+                    cause);
+        }
+    }
+
+    /**
+     * Throws a PatchErrorException using the provided parameters.
+     * @param errorCode the error code for the exception
+     * @param methodName the method throwing the exception
+     * @param cause the underlying cause of the exception (if any, otherwise null)
+     * @param params any parameters for formatting the error message
+     * @throws PatchErrorException always
+     */
+    protected static void raisePatchErrorException(ApacheAtlasOMRSErrorCode errorCode, String methodName, Throwable cause, String ...params) throws PatchErrorException {
+        if (cause == null) {
+            throw new PatchErrorException(errorCode.getMessageDefinition(params),
+                    RelationshipDefMapping.class.getName(),
+                    methodName);
+        } else {
+            throw new PatchErrorException(errorCode.getMessageDefinition(params),
+                    RelationshipDefMapping.class.getName(),
+                    methodName,
+                    cause);
+        }
     }
 
 }

--- a/apache-atlas-adapter/src/main/resources/TypeDefMappings.json
+++ b/apache-atlas-adapter/src/main/resources/TypeDefMappings.json
@@ -14,6 +14,10 @@
     "omrs": "Asset",
     "propertyMappings": [
       {
+        "atlas": "qualifiedName",
+        "omrs": "qualifiedName"
+      },
+      {
         "atlas": "name",
         "omrs": "name"
       },
@@ -29,11 +33,47 @@
   },
   {
     "atlas": "DataSet",
-    "omrs": "DataSet"
+    "omrs": "DataSet",
+    "propertyMappings": [
+      {
+        "atlas": "qualifiedName",
+        "omrs": "qualifiedName"
+      },
+      {
+        "atlas": "name",
+        "omrs": "name"
+      },
+      {
+        "atlas": "description",
+        "omrs": "description"
+      },
+      {
+        "atlas": "owner",
+        "omrs": "owner"
+      }
+    ]
   },
   {
     "atlas": "Process",
-    "omrs": "Process"
+    "omrs": "Process",
+    "propertyMappings": [
+      {
+        "atlas": "qualifiedName",
+        "omrs": "qualifiedName"
+      },
+      {
+        "atlas": "name",
+        "omrs": "name"
+      },
+      {
+        "atlas": "description",
+        "omrs": "description"
+      },
+      {
+        "atlas": "owner",
+        "omrs": "owner"
+      }
+    ]
   },
   {
     "atlas": "hbase_namespace",
@@ -447,10 +487,6 @@
         "omrs": "description"
       },
       {
-        "atlas": "comment",
-        "omrs": "comment"
-      },
-      {
         "atlas": "tableType",
         "omrs": "nativeClass"
       }
@@ -508,10 +544,6 @@
       {
         "atlas": "description",
         "omrs": "description"
-      },
-      {
-        "atlas": "comment",
-        "omrs": "comment"
       }
     ]
   },

--- a/apache-atlas-adapter/src/main/resources/TypeDefMappings.json
+++ b/apache-atlas-adapter/src/main/resources/TypeDefMappings.json
@@ -36,6 +36,223 @@
     "omrs": "Process"
   },
   {
+    "atlas": "hbase_namespace",
+    "omrs": "DataStore",
+    "propertyMappings": [
+      {
+        "atlas": "qualifiedName",
+        "omrs": "qualifiedName"
+      },
+      {
+        "atlas": "name",
+        "omrs": "name"
+      },
+      {
+        "atlas": "description",
+        "omrs": "description"
+      },
+      {
+        "atlas": "owner",
+        "omrs": "owner"
+      },
+      {
+        "atlas": "createTime",
+        "omrs": "createTime"
+      },
+      {
+        "atlas": "modifiedTime",
+        "omrs": "modifiedTime"
+      }
+    ]
+  },
+  {
+    "atlas": "hbase_namespace",
+    "omrs": "Connection",
+    "prefix": "HBNC",
+    "propertyMappings": [
+      {
+        "atlas": "qualifiedName",
+        "omrs": "qualifiedName"
+      },
+      {
+        "atlas": "clusterName",
+        "omrs": "displayName"
+      },
+      {
+        "atlas": "description",
+        "omrs": "description"
+      },
+      {
+        "atlas": "parameters",
+        "omrs": "configurationProperties"
+      }
+    ]
+  },
+  {
+    "atlas": "hbase_namespace",
+    "omrs": "ConnectionToAsset",
+    "prefix": "HBNCTA",
+    "endpointMappings": [
+      {
+        "omrs": "connections",
+        "prefix": "HBNC"
+      },
+      {
+        "omrs": "asset"
+      }
+    ]
+  },
+  {
+    "atlas": "hbase_namespace",
+    "omrs": "Endpoint",
+    "prefix": "HBNE",
+    "propertyMappings": [
+      {
+        "atlas": "qualifiedName",
+        "omrs": "qualifiedName"
+      },
+      {
+        "atlas": "clusterName",
+        "omrs": "name"
+      },
+      {
+        "atlas": "description",
+        "omrs": "description"
+      }
+    ]
+  },
+  {
+    "atlas": "hbase_namespace",
+    "omrs": "ConnectionEndpoint",
+    "prefix": "HBNCE",
+    "endpointMappings": [
+      {
+        "omrs": "connectionEndpoint",
+        "prefix": "HBNE"
+      },
+      {
+        "omrs": "connections",
+        "prefix": "HBNC"
+      }
+    ]
+  },
+  {
+    "atlas": "hbase_table",
+    "omrs": "DataSet",
+    "propertyMappings": [
+      {
+        "atlas": "qualifiedName",
+        "omrs": "qualifiedName"
+      },
+      {
+        "atlas": "name",
+        "omrs": "name"
+      },
+      {
+        "atlas": "description",
+        "omrs": "description"
+      },
+      {
+        "atlas": "owner",
+        "omrs": "owner"
+      }
+    ]
+  },
+  {
+    "atlas": "hbase_table_namespace",
+    "omrs": "DataContentForDataSet",
+    "endpointMappings": [
+      {
+        "atlas": "namespace",
+        "omrs": "dataContent"
+      },
+      {
+        "atlas": "tables",
+        "omrs": "supportedDataSets"
+      }
+    ]
+  },
+  {
+    "omrs": "SchemaElement"
+  },
+  {
+    "omrs": "SchemaType"
+  },
+  {
+    "omrs": "ComplexSchemaType"
+  },
+  {
+    "atlas": "hbase_column_family",
+    "omrs": "TabularSchemaType",
+    "propertyMappings": [
+      {
+        "atlas": "qualifiedName",
+        "omrs": "qualifiedName"
+      },
+      {
+        "atlas": "name",
+        "omrs": "displayName"
+      },
+      {
+        "atlas": "owner",
+        "omrs": "author"
+      },
+      {
+        "atlas": "dataBlockEncoding",
+        "omrs": "encodingStandard"
+      }
+    ]
+  },
+  {
+    "atlas": "hbase_table_column_families",
+    "omrs": "AssetSchemaType",
+    "endpointMappings": [
+      {
+        "atlas": "table",
+        "omrs": "describesAssets"
+      },
+      {
+        "atlas": "column_families",
+        "omrs": "schema"
+      }
+    ]
+  },
+  {
+    "omrs": "SchemaAttribute"
+  },
+  {
+    "atlas": "hbase_column",
+    "omrs": "TabularColumn",
+    "propertyMappings": [
+      {
+        "atlas": "qualifiedName",
+        "omrs": "qualifiedName"
+      },
+      {
+        "atlas": "name",
+        "omrs": "displayName"
+      },
+      {
+        "atlas": "description",
+        "omrs": "description"
+      }
+    ]
+  },
+  {
+    "atlas": "hbase_column_family_columns",
+    "omrs": "AttributeForSchema",
+    "endpointMappings": [
+      {
+        "atlas": "column_family",
+        "omrs": "parentSchemas"
+      },
+      {
+        "atlas": "columns",
+        "omrs": "attributes"
+      }
+    ]
+  },
+  {
     "atlas": "hdfs_path",
     "omrs": "FileFolder",
     "propertyMappings": [
@@ -299,6 +516,15 @@
     ]
   },
   {
+    "omrs": "SimpleSchemaType"
+  },
+  {
+    "omrs": "PrimitiveSchemaType"
+  },
+  {
+    "omrs": "TabularColumnType"
+  },
+  {
     "atlas": "hive_column",
     "omrs": "RelationalColumnType",
     "prefix": "RCT",
@@ -347,211 +573,6 @@
       {
         "omrs": "attributes",
         "atlas": "columns"
-      }
-    ]
-  },
-  {
-    "atlas": "hbase_namespace",
-    "omrs": "DataStore",
-    "propertyMappings": [
-      {
-        "atlas": "qualifiedName",
-        "omrs": "qualifiedName"
-      },
-      {
-        "atlas": "name",
-        "omrs": "name"
-      },
-      {
-        "atlas": "description",
-        "omrs": "description"
-      },
-      {
-        "atlas": "owner",
-        "omrs": "owner"
-      },
-      {
-        "atlas": "createTime",
-        "omrs": "createTime"
-      },
-      {
-        "atlas": "modifiedTime",
-        "omrs": "modifiedTime"
-      }
-    ]
-  },
-  {
-    "atlas": "hbase_namespace",
-    "omrs": "Connection",
-    "prefix": "HBNC",
-    "propertyMappings": [
-      {
-        "atlas": "qualifiedName",
-        "omrs": "qualifiedName"
-      },
-      {
-        "atlas": "clusterName",
-        "omrs": "displayName"
-      },
-      {
-        "atlas": "description",
-        "omrs": "description"
-      },
-      {
-        "atlas": "parameters",
-        "omrs": "configurationProperties"
-      }
-    ]
-  },
-  {
-    "atlas": "hbase_namespace",
-    "omrs": "ConnectionToAsset",
-    "prefix": "HBNCTA",
-    "endpointMappings": [
-      {
-        "omrs": "connections",
-        "prefix": "HBNC"
-      },
-      {
-        "omrs": "asset"
-      }
-    ]
-  },
-  {
-    "atlas": "hbase_namespace",
-    "omrs": "Endpoint",
-    "prefix": "HBNE",
-    "propertyMappings": [
-      {
-        "atlas": "qualifiedName",
-        "omrs": "qualifiedName"
-      },
-      {
-        "atlas": "clusterName",
-        "omrs": "name"
-      },
-      {
-        "atlas": "description",
-        "omrs": "description"
-      }
-    ]
-  },
-  {
-    "atlas": "hbase_namespace",
-    "omrs": "ConnectionEndpoint",
-    "prefix": "HBNCE",
-    "endpointMappings": [
-      {
-        "omrs": "connectionEndpoint",
-        "prefix": "HBNE"
-      },
-      {
-        "omrs": "connections",
-        "prefix": "HBNC"
-      }
-    ]
-  },
-  {
-    "atlas": "hbase_table",
-    "omrs": "DataSet",
-    "propertyMappings": [
-      {
-        "atlas": "qualifiedName",
-        "omrs": "qualifiedName"
-      },
-      {
-        "atlas": "name",
-        "omrs": "name"
-      },
-      {
-        "atlas": "description",
-        "omrs": "description"
-      },
-      {
-        "atlas": "owner",
-        "omrs": "owner"
-      }
-    ]
-  },
-  {
-    "atlas": "hbase_table_namespace",
-    "omrs": "DataContentForDataSet",
-    "endpointMappings": [
-      {
-        "atlas": "namespace",
-        "omrs": "dataContent"
-      },
-      {
-        "atlas": "tables",
-        "omrs": "supportedDataSets"
-      }
-    ]
-  },
-  {
-    "atlas": "hbase_column_family",
-    "omrs": "TabularSchemaType",
-    "propertyMappings": [
-      {
-        "atlas": "qualifiedName",
-        "omrs": "qualifiedName"
-      },
-      {
-        "atlas": "name",
-        "omrs": "displayName"
-      },
-      {
-        "atlas": "owner",
-        "omrs": "author"
-      },
-      {
-        "atlas": "dataBlockEncoding",
-        "omrs": "encodingStandard"
-      }
-    ]
-  },
-  {
-    "atlas": "hbase_table_column_families",
-    "omrs": "AssetSchemaType",
-    "endpointMappings": [
-      {
-        "atlas": "table",
-        "omrs": "describesAssets"
-      },
-      {
-        "atlas": "column_families",
-        "omrs": "schema"
-      }
-    ]
-  },
-  {
-    "atlas": "hbase_column",
-    "omrs": "TabularColumn",
-    "propertyMappings": [
-      {
-        "atlas": "qualifiedName",
-        "omrs": "qualifiedName"
-      },
-      {
-        "atlas": "name",
-        "omrs": "displayName"
-      },
-      {
-        "atlas": "description",
-        "omrs": "description"
-      }
-    ]
-  },
-  {
-    "atlas": "hbase_column_family_columns",
-    "omrs": "AttributeForSchema",
-    "endpointMappings": [
-      {
-        "atlas": "column_family",
-        "omrs": "parentSchemas"
-      },
-      {
-        "atlas": "columns",
-        "omrs": "attributes"
       }
     ]
   },

--- a/cts/charts/ec-cts-apacheatlas/templates/configmap.yaml
+++ b/cts/charts/ec-cts-apacheatlas/templates/configmap.yaml
@@ -30,5 +30,5 @@ data:
   ATLAS_SERVER: {{ .Values.apacheatlas.proxyserver }}
 
   # Used for downloads
-  CONNECTOR_URL: https://odpi.jfrog.io/odpi/egeria-{{ .Values.release.repo }}-local/org/odpi/egeria/egeria-connector-apache-atlas-package/{{ .Values.release.version }}/egeria-connector-apache-atlas-package-{{ .Values.release.version }}-jar-with-dependencies.jar
+  CONNECTOR_URL: https://odpi.jfrog.io/odpi/egeria-{{ .Values.release.repo }}-local/org/odpi/egeria/egeria-connector-hadoop-ecosystem-package/{{ .Values.release.version }}/egeria-connector-hadoop-ecosystem-package-{{ .Values.release.version }}-jar-with-dependencies.jar
   CTS_REPORT_NAME: {{ .Release.Name }}

--- a/cts/charts/ec-cts-apacheatlas/values.yaml
+++ b/cts/charts/ec-cts-apacheatlas/values.yaml
@@ -16,7 +16,7 @@ egeria:
   server: myserver
 
 release:
-  version: 2.0-SNAPSHOT
+  version: 2.1-SNAPSHOT
   repo: snapshot
 
 image:

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>egeria-connector-hadoop-ecosystem</artifactId>
         <groupId>org.odpi.egeria</groupId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -32,6 +32,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.odpi.egeria</groupId>
     <artifactId>egeria-connector-hadoop-ecosystem</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.1-SNAPSHOT</version>
 
     <url>https://odpi.github.io/Egeria</url>
 
@@ -80,7 +80,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <open-metadata.version>2.0-SNAPSHOT</open-metadata.version>
+        <open-metadata.version>2.1-SNAPSHOT</open-metadata.version>
         <!-- Level of Java  -->
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -90,8 +90,8 @@
         <!-- Versions of dependent libraries -->
         <apacheatlas.version>2.0.0</apacheatlas.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <jackson.version>2.11.0</jackson.version>
-        <spring.version>5.2.2.RELEASE</spring.version>
+        <jackson.version>2.11.1</jackson.version>
+        <spring.version>5.2.8.RELEASE</spring.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
@@ -517,8 +517,6 @@
                     <configuration>
                         <forkCount>3</forkCount>
                         <reuseForks>true</reuseForks>
-                        <!--suppress UnresolvedMavenProperty -->
-                        <argLine>-Xmx1024m ${argLine}</argLine>
                         <includes>
                             <include>**/*Test.java</include>
                         </includes>
@@ -526,18 +524,6 @@
                             <org.slf4j.simpleLogger.defaultLogLevel>INFO</org.slf4j.simpleLogger.defaultLogLevel>
                         </systemPropertyVariables>
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.junit.jupiter</groupId>
-                            <artifactId>junit-jupiter-engine</artifactId>
-                            <version>${junit.jupiter.version}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.junit.jupiter</groupId>
-                            <artifactId>junit-jupiter-api</artifactId>
-                            <version>${junit.jupiter.version}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.mock-server</groupId>


### PR DESCRIPTION
Adds constructs to handle super-type mappings:

- placeholder mappings for super-types that are not directly mapped, to ensure any changed attributes (via type def patches) at the super-type level are handled
- traversal of returned Apache Atlas types up to the most granular Egeria type level that _is_ mapped (eg. `hive_process` is not directly mapped, but will end up being mapped as a `Process`) -- theoretically this should allow all Atlas types to at least be mapped to `Referenceable`