### PR TITLE
Allow simple re-use of connector against older Egeria releases

### DIFF
--- a/apache-atlas-adapter/pom.xml
+++ b/apache-atlas-adapter/pom.xml
@@ -77,11 +77,11 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
         </dependency>
-        <!-- <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>jsr311-api</artifactId>
-        </dependency> -->
         <!-- Testing -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>

--- a/apache-atlas-adapter/src/main/java/org/odpi/egeria/connectors/apache/atlas/repositoryconnector/mapping/EntityMappingAtlas2OMRS.java
+++ b/apache-atlas-adapter/src/main/java/org/odpi/egeria/connectors/apache/atlas/repositoryconnector/mapping/EntityMappingAtlas2OMRS.java
@@ -364,11 +364,11 @@ public class EntityMappingAtlas2OMRS {
             summary = atlasRepositoryConnector.getRepositoryHelper().getSkeletonEntitySummary(
                     atlasRepositoryConnector.getRepositoryName(),
                     atlasRepositoryConnector.getMetadataCollectionId(),
-                    atlasRepositoryConnector.getMetadataCollectionName(),
                     InstanceProvenanceType.LOCAL_COHORT,
                     userId,
                     omrsTypeDefName
             );
+            summary.setMetadataCollectionName(atlasRepositoryConnector.getMetadataCollectionName());
             String guid = atlasEntity.getGuid();
             AtlasGuid atlasGuid = new AtlasGuid(guid, prefix);
             summary.setGUID(atlasGuid.toString());
@@ -396,11 +396,11 @@ public class EntityMappingAtlas2OMRS {
             detail = atlasRepositoryConnector.getRepositoryHelper().getSkeletonEntity(
                     atlasRepositoryConnector.getRepositoryName(),
                     atlasRepositoryConnector.getMetadataCollectionId(),
-                    atlasRepositoryConnector.getMetadataCollectionName(),
                     InstanceProvenanceType.LOCAL_COHORT,
                     userId,
                     omrsTypeDefName
             );
+            detail.setMetadataCollectionName(atlasRepositoryConnector.getMetadataCollectionName());
             switch(atlasEntity.getStatus()) {
                 case ACTIVE:
                     detail.setStatus(InstanceStatus.ACTIVE);
@@ -503,9 +503,6 @@ public class EntityMappingAtlas2OMRS {
                         // TODO: currently hard-coded to ASSIGNED classifications, need to also handle PROPAGATED
                         Classification classification = atlasRepositoryConnector.getRepositoryHelper().getNewClassification(
                                 repositoryName,
-                                atlasRepositoryConnector.getMetadataCollectionId(),
-                                atlasRepositoryConnector.getMetadataCollectionName(),
-                                InstanceProvenanceType.LOCAL_COHORT,
                                 userId,
                                 atlasClassificationName,
                                 omrsTypeDefName,
@@ -513,6 +510,9 @@ public class EntityMappingAtlas2OMRS {
                                 null,
                                 omrsClassificationProperties
                         );
+                        classification.setMetadataCollectionId(atlasRepositoryConnector.getMetadataCollectionId());
+                        classification.setMetadataCollectionName(atlasRepositoryConnector.getMetadataCollectionName());
+                        classification.setInstanceProvenanceType(InstanceProvenanceType.LOCAL_COHORT);
                         // Setting classification mod details based on the overall entity (nothing more fine-grained in Atlas)
                         classification.setCreatedBy(omrsObj.getCreatedBy());
                         classification.setCreateTime(omrsObj.getCreateTime());

--- a/apache-atlas-adapter/src/test/java/org/odpi/egeria/connectors/apache/atlas/mocks/MockServerExpectations.java
+++ b/apache-atlas-adapter/src/test/java/org/odpi/egeria/connectors/apache/atlas/mocks/MockServerExpectations.java
@@ -149,9 +149,11 @@ public class MockServerExpectations implements PluginExpectationInitializer {
         mockServerClient
                 .when(typedefsRequest(), Times.exactly(1))
                 .respond(withResponse(getResourceFileContents("types_vanilla.json")));
-        mockServerClient
+        // Not clear why the below is failing locally, but it causes a 'Connection reset by peer' error,
+        // and does not actually appear to be used in any test cases -- so leaving out for now.
+        /*mockServerClient
                 .when(typedefsRequest())
-                .respond(withResponse(getResourceFileContents("types_updated.json")));
+                .respond(withResponse(getResourceFileContents("types_updated.json")));*/
     }
 
     private void setTypeDetails(MockServerClient mockServerClient, String typeFilename) {

--- a/apache-atlas-adapter/src/test/resources/logback-test.xml
+++ b/apache-atlas-adapter/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="OFF">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
         <junit.version>4.12</junit.version>
         <surefire.plugin.version>3.0.0-M5</surefire.plugin.version>
+        <logback.version>1.2.3</logback.version>
         <testng.version>7.4.0</testng.version>
         <mock-server.version>5.11.2</mock-server.version>
         <sleepycat.version>18.3.12</sleepycat.version>
@@ -141,10 +142,27 @@
                 <version>${spring.version}</version>
             </dependency>
             <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
                 <scope>test</scope>
                 <version>${testng.version}</version>
+                <exclusions>
+                    <!-- Exclude snakeyaml, which has open CVEs and is unused -->
+                    <exclusion>
+                        <groupId>org.yaml</groupId>
+                        <artifactId>snakeyaml</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.ant</groupId>
+                        <artifactId>ant</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.mock-server</groupId>
@@ -355,12 +373,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <!-- <dependency>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>jsr311-api</artifactId>
-                <scope>compile</scope>
-                <version>1.1.1</version>
-            </dependency> -->
             <!-- Testing dependencies -->
             <dependency>
                 <groupId>org.odpi.egeria</groupId>


### PR DESCRIPTION
Reverts to deprecated helper methods to allow simple re-use even with older Egeria releases (and older types)